### PR TITLE
Include S responses in returned data

### DIFF
--- a/client/session.go
+++ b/client/session.go
@@ -101,6 +101,9 @@ func (ses *Session) SimpleCmd(cmd string, params string) (data []byte, err error
 		}
 
 		if scmd == "OK" {
+			if data != nil && data[len(data)-1] == '\n' {
+				data = data[:len(data)-1]
+			}
 			return data, nil
 		}
 		if scmd == "ERR" {
@@ -109,6 +112,11 @@ func (ses *Session) SimpleCmd(cmd string, params string) (data []byte, err error
 		}
 		if scmd == "D" {
 			data = append(data, []byte(sparams)...)
+			data = append(data, "\n"...)
+		}
+		if scmd == "S" {
+			data = append(data, []byte(sparams)...)
+			data = append(data, "\n"...)
 		}
 	}
 }

--- a/common/io.go
+++ b/common/io.go
@@ -79,7 +79,7 @@ func (p *Pipe) ReadLine() (cmd string, params string, err error) {
 		line = p.scnr.Text()
 
 		// We got something that looks like a message. Let's parse it.
-		if !strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "S ") && len(strings.TrimSpace(line)) != 0 {
+		if !strings.HasPrefix(line, "#") && len(strings.TrimSpace(line)) != 0 {
 			break
 		}
 	}


### PR DESCRIPTION
GnuPG often returns data using a `S` response:

```
nephirus@soridormi:~$ gpg-connect-agent
> scd getattr KEY-FPR
S KEY-FPR 1 0E7135AB312958BEA5A2690CFCB8E57265C1B201
S KEY-FPR 2 E8A72FFE3102F9D23CAB1D5AEAB76694BD5CD8ED
S KEY-FPR 3 75B6621F072BCDD53B66F49B387993A328A35184
OK
```

Perhaps the content of `S` responses should be also returned as received data.